### PR TITLE
Update responsive-tabs.js

### DIFF
--- a/js/responsive-tabs.js
+++ b/js/responsive-tabs.js
@@ -22,7 +22,12 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 		$.each( tabGroups, function () {
 			var $tabGroup   = $( this );
 			var tabs        = $tabGroup.find( 'li a' );
-			var collapseDiv = $( '<div></div>', {
+			var collapseDiv;
+			
+			if ($tabGroup.attr( 'id' ) === undefined)
+				$tabGroup.attr( 'id', 'tabs-' + index );
+			
+			collapseDiv = $( '<div></div>', {
 				'class' : 'panel-group responsive' + visible,
 				'id'    : 'collapse-' + $tabGroup.attr( 'id' )
 			} );


### PR DESCRIPTION
Tabs' contents would not be repopulated from its respective panel-body if the nav-tabs element didn't have a pre-defined ID.