### PR TITLE
Fix for nested panels breaking on tab to panel conversion

### DIFF
--- a/js/responsive-tabs.js
+++ b/js/responsive-tabs.js
@@ -114,7 +114,7 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 				// Convert tab to panel and move to destination
 				$( tabContent )
 					.removeClass( 'tab-pane' )
-					.addClass( 'panel-body' )
+					.addClass( 'panel-body fw-previous-tab-pane' )
 					.appendTo( $( destinationId ) );
 
 			} );
@@ -133,11 +133,11 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 			var destination   = $( destinationId ).next( '.tab-content' )[ 0 ];
 
 			// Find the panel contents
-			var panelContents = $( panelGroup ).find( '.panel-body' );
+			var panelContents = $( panelGroup ).find( '.panel-body.fw-previous-tab-pane' );
 
 			// Convert to tab and move to destination
 			panelContents
-				.removeClass( 'panel-body' )
+				.removeClass( 'panel-body fw-previous-tab-pane' )
 				.addClass( 'tab-pane' )
 				.appendTo( $( destination ) );
 


### PR DESCRIPTION
Due to the fact that the plugin searches for all `panel-body` classed elements to convert back into `tab-pane` classed elements when converting panels back to tabs, any tab pane content that contains other panels will find their `panel-body` content removed and made into a `tab-pane`.

This change adds an additional namespaced class of `fw-previous-tab-pane` when converting a tab pane to a panel, and then only converts `panel-body` classed elements which also have the `fw-previous-tab-pane` class. This leaves any nested panels alone.