### PR TITLE
Update responsive-tabs.js

### DIFF
--- a/js/responsive-tabs.js
+++ b/js/responsive-tabs.js
@@ -72,7 +72,7 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 				);
 			} );
 
-			$tabGroup.next().after( collapseDiv );
+			$tabGroup.parent().find('.tab-content.responsive').after( collapseDiv );
 			$tabGroup.addClass( hidden );
 			$( '.tab-content.responsive' ).addClass( hidden );
 		} );
@@ -105,7 +105,7 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 		$.each( tabGroups, function ( index, tabGroup ) {
 
 			// Find the tab
-			var tabContents = $( tabGroup ).next( '.tab-content' ).find( '.tab-pane' );
+			var tabContents = $( tabGroup ).parent().find('.tab-content.responsive').find( '.tab-pane' );;
 
 			$.each( tabContents, function ( index, tabContent ) {
 				// Find the id to move the element to


### PR DESCRIPTION
By making the following changes you allow the actual tabs themselves to be above(before) or below(after) the panel content. Without this change if the code has the order of <div id="tabcontentbelow" class="tab-content responsive"><ul id="tabnavbelow" class="nav nav-tabs responsive"> instead of the more common <ul id="tabnavbelow" class="nav nav-tabs responsive"><div id="tabcontentbelow" class="tab-content responsive"> the script will not work. The reason for this is two .next usages that are based on the assumption that it will be written in that order. The correction goes based off the classes and still works with multiple tabs on 1 page. This allows for tabs above, below, left, and right.